### PR TITLE
Trt refactor add configs

### DIFF
--- a/src/flux/trt/engine/base_engine.py
+++ b/src/flux/trt/engine/base_engine.py
@@ -24,6 +24,8 @@ from cuda import cudart
 from polygraphy.backend.common import bytes_from_path
 from polygraphy.backend.trt import engine_from_bytes
 
+from flux.trt.trt_config import TRTBaseConfig
+
 TRT_LOGGER = trt.Logger(trt.Logger.ERROR)
 
 
@@ -57,12 +59,9 @@ class BaseEngine(ABC):
         pass
 
     @abstractmethod
-    def to(self, device: str) -> "BaseEngine":
+    def to(self, device: str | torch.device) -> "BaseEngine":
         pass
 
-    @abstractmethod
-    def set_stream(self, stream):
-        pass
 
     @abstractmethod
     def load(self):
@@ -80,10 +79,11 @@ class BaseEngine(ABC):
 class Engine(BaseEngine):
     def __init__(
         self,
-        engine_path: str,
+        trt_config: TRTBaseConfig,
+        stream: cudart.cudaStream_t,
     ):
-        self.engine_path = engine_path
-        self.stream = None
+        self.trt_config = trt_config
+        self.stream = stream
         self.engine: trt.ICudaEngine | None = None
         self.context = None
         self.tensors = OrderedDict()
@@ -120,29 +120,29 @@ class Engine(BaseEngine):
 
     def load(self):
         if self.engine is not None:
-            print(f"[W]: Engine {self.engine_path} already loaded, skip reloading")
+            print(f"[W]: Engine {self.trt_config.engine_path} already loaded, skip reloading")
             return
 
         if not hasattr(self, "engine_bytes_cpu") or self.engine_bytes_cpu is None:
             # keep a cpu copy of the engine to reduce reloading time.
-            print(f"Loading TensorRT engine to cpu bytes: {self.engine_path}")
-            self.engine_bytes_cpu = bytes_from_path(self.engine_path)
+            print(f"Loading TensorRT engine to cpu bytes: {self.trt_config.engine_path}")
+            self.engine_bytes_cpu = bytes_from_path(self.trt_config.engine_path)
 
-        print(f"Loading TensorRT engine: {self.engine_path}")
+        print(f"Loading TensorRT engine: {self.trt_config.engine_path}")
         self.engine = engine_from_bytes(self.engine_bytes_cpu)
 
     def unload(self):
         if self.engine is not None:
-            print(f"Unloading TensorRT engine: {self.engine_path}")
+            print(f"Unloading TensorRT engine: {self.trt_config.engine_path}")
             del self.engine
             self.engine = None
             gc.collect()
         else:
-            print(f"[W]: Unload an unloaded engine {self.engine_path}, skip unloading")
+            print(f"[W]: Unload an unloaded engine {self.trt_config.engine_path}, skip unloading")
 
     def activate(
         self,
-        device: str,
+        device: str | torch.device,
         device_memory: int | None = None,
     ):
         self.device = device
@@ -165,7 +165,7 @@ class Engine(BaseEngine):
     def allocate_buffers(
         self,
         shape_dict: dict[str, tuple],
-        device="cuda",
+        device: str | torch.device = "cuda",
     ):
         for binding in range(self.engine.num_io_tensors):
             tensor_name = self.engine.get_tensor_name(binding)

--- a/src/flux/trt/engine/clip_engine.py
+++ b/src/flux/trt/engine/clip_engine.py
@@ -15,27 +15,26 @@
 # limitations under the License.
 
 import torch
+from cuda.cudart import cudaStream_t
 from transformers import CLIPTokenizer
 
 from flux.trt.engine import Engine
-from flux.trt.mixin import CLIPMixin
+from flux.trt.trt_config import ClipConfig
 
 
-class CLIPEngine(CLIPMixin, Engine):
+class CLIPEngine(Engine):
     def __init__(
         self,
-        text_maxlen: int,
-        hidden_size: int,
-        engine_path: str,
+        trt_config: ClipConfig,
+        stream: cudaStream_t,
     ):
         super().__init__(
-            text_maxlen=text_maxlen,
-            hidden_size=hidden_size,
-            engine_path=engine_path,
+            trt_config=trt_config,
+            stream=stream,
         )
         self.tokenizer = CLIPTokenizer.from_pretrained(
             "openai/clip-vit-large-patch14",
-            max_length=self.text_maxlen,
+            max_length=self.trt_config.text_maxlen,
         )
 
     def __call__(
@@ -48,7 +47,7 @@ class CLIPEngine(CLIPMixin, Engine):
             feed_dict = self.tokenizer(
                 prompt,
                 truncation=True,
-                max_length=self.text_maxlen,
+                max_length=self.trt_config.text_maxlen,
                 return_length=False,
                 return_overflowing_tokens=False,
                 padding="max_length",
@@ -65,8 +64,8 @@ class CLIPEngine(CLIPMixin, Engine):
         batch_size: int,
     ) -> dict[str, tuple]:
         return {
-            "input_ids": (batch_size, self.text_maxlen),
-            "pooled_embeddings": (batch_size, self.hidden_size),
+            "input_ids": (batch_size, self.trt_config.text_maxlen),
+            "pooled_embeddings": (batch_size, self.trt_config.hidden_size),
             # Onnx model coming from HF has also this input
-            "text_embeddings": (batch_size, self.text_maxlen, self.hidden_size),
+            "text_embeddings": (batch_size, self.trt_config.text_maxlen, self.trt_config.hidden_size),
         }

--- a/src/flux/trt/engine/t5_engine.py
+++ b/src/flux/trt/engine/t5_engine.py
@@ -15,27 +15,26 @@
 # limitations under the License.
 
 import torch
+from cuda.cudart import cudaStream_t
 from transformers import T5Tokenizer
 
 from flux.trt.engine import Engine
-from flux.trt.mixin import T5Mixin
+from flux.trt.trt_config import T5Config
 
 
-class T5Engine(T5Mixin, Engine):
+class T5Engine(Engine):
     def __init__(
         self,
-        text_maxlen: int,
-        hidden_size: int,
-        engine_path: str,
+        trt_config: T5Config,
+        stream: cudaStream_t,
     ):
         super().__init__(
-            text_maxlen=text_maxlen,
-            hidden_size=hidden_size,
-            engine_path=engine_path,
+            trt_config=trt_config,
+            stream=stream,
         )
         self.tokenizer = T5Tokenizer.from_pretrained(
             "google/t5-v1_1-xxl",
-            max_length=self.text_maxlen,
+            max_length=self.trt_config.text_maxlen,
         )
 
     def __call__(
@@ -49,7 +48,7 @@ class T5Engine(T5Mixin, Engine):
             feed_dict = self.tokenizer(
                 prompt,
                 truncation=True,
-                max_length=self.text_maxlen,
+                max_length=self.trt_config.text_maxlen,
                 return_length=False,
                 return_overflowing_tokens=False,
                 padding="max_length",
@@ -66,6 +65,6 @@ class T5Engine(T5Mixin, Engine):
         batch_size: int,
     ) -> dict[str, tuple]:
         return {
-            "input_ids": (batch_size, self.text_maxlen),
-            "text_embeddings": (batch_size, self.text_maxlen, self.hidden_size),
+            "input_ids": (batch_size, self.trt_config.text_maxlen),
+            "text_embeddings": (batch_size, self.trt_config.text_maxlen, self.trt_config.hidden_size),
         }

--- a/src/flux/trt/engine/vae_engine.py
+++ b/src/flux/trt/engine/vae_engine.py
@@ -18,24 +18,18 @@ import torch
 from cuda import cudart
 
 from flux.trt.engine.base_engine import BaseEngine, Engine
-from flux.trt.mixin import VAEMixin
+from flux.trt.trt_config import VAEDecoderConfig, VAEEncoderConfig
 
 
-class VAEDecoder(VAEMixin, Engine):
+class VAEDecoder(Engine):
     def __init__(
         self,
-        z_channels: int,
-        compression_factor: int,
-        scale_factor: float,
-        shift_factor: float,
-        engine_path: str,
+        trt_config: VAEDecoderConfig,
+        stream: cudart.cudaStream_t,
     ):
         super().__init__(
-            z_channels=z_channels,
-            compression_factor=compression_factor,
-            scale_factor=scale_factor,
-            shift_factor=shift_factor,
-            engine_path=engine_path,
+            trt_config=trt_config,
+            stream=stream,
         )
 
     def __call__(
@@ -50,37 +44,29 @@ class VAEDecoder(VAEMixin, Engine):
         self.allocate_buffers(shape_dict=shape_dict, device=self.device)
 
         z = z.to(dtype=self.tensors["latent"].dtype)
-        z = (z / self.scale_factor) + self.shift_factor
+        z = (z / self.trt_config.scale_factor) + self.trt_config.shift_factor
         feed_dict = {"latent": z}
         images = self.infer(feed_dict=feed_dict)["images"].clone()
         return images
 
     def get_shape_dict(self, batch_size: int, latent_height: int, latent_width: int) -> dict[str, tuple]:
-        image_height, image_width = self.get_img_dim(
-            latent_height=latent_height,
-            latent_width=latent_width,
-        )
+        image_height = self.trt_config._get_img_dim(latent_height)
+        image_width = self.trt_config._get_img_dim(latent_width)
         return {
-            "latent": (batch_size, self.z_channels, latent_height, latent_width),
+            "latent": (batch_size, self.trt_config.z_channels, latent_height, latent_width),
             "images": (batch_size, 3, image_height, image_width),
         }
 
 
-class VAEEncoder(VAEMixin, Engine):
+class VAEEncoder(Engine):
     def __init__(
         self,
-        z_channels: int,
-        compression_factor: int,
-        scale_factor: float,
-        shift_factor: float,
-        engine_path: str,
+        trt_config: VAEEncoderConfig,
+        stream: cudart.cudaStream_t,
     ):
         super().__init__(
-            z_channels=z_channels,
-            compression_factor=compression_factor,
-            scale_factor=scale_factor,
-            shift_factor=shift_factor,
-            engine_path=engine_path,
+            trt_config=trt_config,
+            stream=stream,
         )
 
     def __call__(
@@ -96,17 +82,16 @@ class VAEEncoder(VAEMixin, Engine):
 
         feed_dict = {"images": x}
         latent = self.infer(feed_dict=feed_dict)["latent"].clone()
-        latent = self.scale_factor * (latent - self.shift_factor)
+        latent = self.trt_config.scale_factor * (latent - self.trt_config.shift_factor)
         return latent
 
     def get_shape_dict(self, batch_size: int, image_height: int, image_width: int) -> dict[str, tuple]:
-        latent_height, latent_width = self.get_latent_dim(
-            image_height=image_height,
-            image_width=image_width,
-        )
+        latent_height = self.trt_config._get_latent_dim(image_height)
+        latent_width = self.trt_config._get_latent_dim(image_width)
+
         return {
             "images": (batch_size, 3, image_height, image_width),
-            "latent": (batch_size, self.z_channels, latent_height, latent_width),
+            "latent": (batch_size, self.trt_config.z_channels, latent_height, latent_width),
         }
 
 
@@ -152,11 +137,6 @@ class VAEEngine(BaseEngine):
         self.activate(device=device, device_memory=self.decoder.shared_device_memory)
         return self
 
-    def set_stream(self, stream):
-        self.decoder.set_stream(stream)
-        if self.encoder is not None:
-            self.encoder.set_stream(stream)
-
     def load(self):
         self.decoder.load()
         if self.encoder is not None:
@@ -164,7 +144,7 @@ class VAEEngine(BaseEngine):
 
     def activate(
         self,
-        device: str,
+        device: str | torch.device,
         device_memory: int | None = None,
     ):
         self.decoder.activate(device=device, device_memory=device_memory)

--- a/src/flux/trt/trt_config/__init__.py
+++ b/src/flux/trt/trt_config/__init__.py
@@ -1,0 +1,32 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config, get_config
+from flux.trt.trt_config.clip_trt_config import ClipConfig
+from flux.trt.trt_config.t5_trt_config import T5Config
+from flux.trt.trt_config.transformer_trt_config import TransformerConfig
+from flux.trt.trt_config.vae_trt_config import VAEDecoderConfig, VAEEncoderConfig
+
+__all__ = [
+    "register_config",
+    "get_config",
+    "TRTBaseConfig",
+    "ClipConfig",
+    "T5Config",
+    "TransformerConfig",
+    "VAEDecoderConfig",
+    "VAEEncoderConfig",
+]

--- a/src/flux/trt/trt_config/base_trt_config.py
+++ b/src/flux/trt/trt_config/base_trt_config.py
@@ -1,0 +1,217 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+from abc import abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from colored import fore, style
+from tensorrt import __version__ as trt_version
+
+registry = {}
+
+
+@dataclass
+class TRTBaseConfig:
+    onnx_dir: str
+    engine_dir: str
+    precision: str
+    trt_verbose: bool
+    trt_static_batch: bool
+    trt_static_shape: bool
+    model_name: str
+    onnx_path: str = field(init=False)
+    engine_path: str = field(init=False)
+    trt_tf32: bool
+    trt_bf16: bool
+    trt_fp8: bool
+    trt_fp4: bool
+    trt_build_strongly_typed: bool
+    min_batch: int = 1
+    max_batch: int = 4
+    trt_update_output_names: list[str] | None = None
+    trt_enable_all_tactics: bool = False
+    trt_timing_cache: str | None = None
+    trt_native_instancenorm: bool = True
+    trt_builder_optimization_level: int = 3
+    trt_precision_constraints: str = "none"
+
+    @staticmethod
+    def build_trt_engine(
+        engine_path: str,
+        onnx_path: str,
+        strongly_typed=False,
+        tf32=True,
+        bf16=False,
+        fp8=False,
+        fp4=False,
+        input_profile: dict[str, Any] | None = None,
+        update_output_names: list[str] | None = None,
+        enable_refit=False,
+        enable_all_tactics=False,
+        timing_cache=None,
+        native_instancenorm=True,
+        builder_optimization_level=3,
+        precision_constraints="none",
+        verbose=False,
+    ):
+        print(f"Building TensorRT engine for {onnx_path}: {engine_path}")
+
+        # Base command
+        build_command = [f"polygraphy convert {onnx_path} --convert-to trt --output {engine_path}"]
+
+        # Precision flags
+        build_args = [
+            "--bf16" if bf16 else "",
+            "--tf32" if tf32 else "",
+            "--fp8" if fp8 else "",
+            "--fp4" if fp4 else "",
+            "--strongly-typed" if strongly_typed else "",
+        ]
+
+        # Additional arguments
+        build_args.extend(
+            [
+                "--refittable" if enable_refit else "",
+                "--tactic-sources" if not enable_all_tactics else "",
+                "--onnx-flags native_instancenorm" if native_instancenorm else "",
+                f"--builder-optimization-level {builder_optimization_level}",
+                f"--precision-constraints {precision_constraints}",
+            ]
+        )
+
+        # Timing cache
+        if timing_cache:
+            build_args.extend([f"--load-timing-cache {timing_cache}", f"--save-timing-cache {timing_cache}"])
+
+        # Verbosity setting
+        verbosity = "extra_verbose" if verbose else "error"
+        build_args.append(f"--verbosity {verbosity}")
+
+        # Output names
+        if update_output_names:
+            print(f"Updating network outputs to {update_output_names}")
+            build_args.append(f"--trt-outputs {' '.join(update_output_names)}")
+
+        # Input profiles
+        if input_profile:
+            profile_args = defaultdict(str)
+            for name, dims in input_profile.items():
+                assert len(dims) == 3
+                profile_args["--trt-min-shapes"] += f"{name}:{str(list(dims[0])).replace(' ', '')} "
+                profile_args["--trt-opt-shapes"] += f"{name}:{str(list(dims[1])).replace(' ', '')} "
+                profile_args["--trt-max-shapes"] += f"{name}:{str(list(dims[2])).replace(' ', '')} "
+
+            build_args.extend(f"{k} {v}" for k, v in profile_args.items())
+
+        # Filter out empty strings and join command
+        build_args = [arg for arg in build_args if arg]
+        final_command = " \\\n".join(build_command + build_args)
+
+        # Execute command with improved error handling
+        try:
+            print(f"Engine build command:{fore('yellow')}\n{final_command}\n{style('reset')}")
+            subprocess.run(final_command, check=True, shell=True)
+        except subprocess.CalledProcessError as exc:
+            error_msg = f"Failed to build TensorRT engine. Error details:\nCommand: {exc.cmd}\n"
+            raise RuntimeError(error_msg) from exc
+
+    @classmethod
+    @abstractmethod
+    def from_model(cls, *args, **kwargs) -> Any:
+        raise NotImplementedError("Factory method is missing")
+
+    @abstractmethod
+    def get_input_profile(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ) -> dict[str, Any]:
+        """
+        Generate max and min shape that each input of a TRT engine can have.
+
+        Subclasses must implement this method to return a dictionary that defines
+        the input profile based on the provided parameters. The input profile typically
+        includes details such as the expected shape of input tensors, whether the batch size
+        or image dimensions are fixed, and any additional configuration required by the
+        data processing or model inference pipeline.
+
+        Args:
+            batch_size (int): The number of images per batch.
+            image_height (int): Default height of each image in pixels.
+            image_width (int): Defailt width of each image in pixels.
+            static_batch (bool): Flag indicating if the batch size is fixed (static).
+            static_shape (bool): Flag indicating if the image dimensions are fixed (static).
+
+        Returns:
+            dict[str, Any]: A dictionary representing the input profile configuration.
+
+        Raises:
+            NotImplementedError: If the subclass does not override this abstract method.
+        """
+        pass
+
+    @abstractmethod
+    def check_dims(self, *args, **kwargs) -> None | tuple[int, int]:
+        """helper function that check the dimentions associated to each input of a TRT engine"""
+        pass
+
+    def __post_init__(self):
+        self.onnx_path = self._get_onnx_path()
+        self.engine_path = self._get_engine_path()
+        assert os.path.isfile(self.onnx_path), "onnx_path do not exists: {}".format(self.onnx_path)
+
+    def _get_onnx_path(self) -> str:
+        onnx_model_dir = os.path.join(
+            self.onnx_dir,
+            self.model_name + ".opt",
+        )
+        return os.path.join(onnx_model_dir, "model.onnx")
+
+    def _get_engine_path(self) -> str:
+        return os.path.join(
+            self.engine_dir,
+            self.model_name + ".trt" + trt_version + ".plan",
+        )
+
+
+def register_config(model_name: str, tf32=True, bf16=False, fp8=False, fp4=False, t5_fp8=False):
+    """Decorator to register a configuration class with specific flag conditions."""
+
+    def decorator(cls):
+        if model_name == "t5":
+            key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}_t5-fp8={t5_fp8}"
+        else:
+            key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}"
+        registry[key] = cls
+        return cls
+
+    return decorator
+
+
+def get_config(model_name: str, tf32=True, bf16=True, fp8=False, fp4=False, t5_fp8=False) -> TRTBaseConfig:
+    """Retrieve the appropriate configuration instance based on current flags."""
+    if model_name == "t5":
+        key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}_t5-fp8={t5_fp8}"
+    else:
+        key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}"
+    return registry[key]

--- a/src/flux/trt/trt_config/base_trt_config.py
+++ b/src/flux/trt/trt_config/base_trt_config.py
@@ -218,24 +218,18 @@ class TRTBaseConfig:
         )
 
 
-def register_config(model_name: str, tf32=True, bf16=False, fp8=False, fp4=False, t5_fp8=False):
+def register_config(model_name: str, tf32=True, bf16=False, fp8=False, fp4=False):
     """Decorator to register a configuration class with specific flag conditions."""
 
     def decorator(cls):
-        if model_name == "t5":
-            key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}_t5-fp8={t5_fp8}"
-        else:
-            key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}"
+        key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}"
         registry[key] = cls
         return cls
 
     return decorator
 
 
-def get_config(model_name: str, tf32=True, bf16=True, fp8=False, fp4=False, t5_fp8=False) -> TRTBaseConfig:
+def get_config(model_name: str, tf32=True, bf16=True, fp8=False, fp4=False) -> TRTBaseConfig:
     """Retrieve the appropriate configuration instance based on current flags."""
-    if model_name == "t5":
-        key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}_t5-fp8={t5_fp8}"
-    else:
-        key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}"
+    key = f"model={model_name}_tf32={tf32}_bf16={bf16}_fp8={fp8}_fp4={fp4}"
     return registry[key]

--- a/src/flux/trt/trt_config/base_trt_config.py
+++ b/src/flux/trt/trt_config/base_trt_config.py
@@ -65,12 +65,36 @@ class TRTBaseConfig:
         update_output_names: list[str] | None = None,
         enable_refit=False,
         enable_all_tactics=False,
-        timing_cache=None,
+        timing_cache: str | None = None,
         native_instancenorm=True,
         builder_optimization_level=3,
         precision_constraints="none",
         verbose=False,
     ):
+        """
+        Metod used to build a TRT engine from a given set of flags or configurations using polygraphy.
+
+        Args:
+            engine_path (str): Output path used to store the build engine.
+            onnx_path (str): Path containing an onnx model used to generated the engine.
+            strongly_typed (bool): Flag indicating if the engine should be strongly typed.
+            tf32 (bool): Whether to build the engine with TF32 precision enabled.
+            bf16 (bool): Whether to build the engine with BF16 precision enabled.
+            fp8 (bool): Whether to build the engine with FP8 precision enabled. Refer to plain dataype and do not interfer with quantization introduced by modelopt.
+            fp4 (bool): Whether to build the engine with FP4 precision enabled. Refer to plain dataype and do not interfer with quantization introduced by modelopt.
+            input_profile (dict[str, Any]): A set of optimization profiles to add to the configuration. Only needed for networks with dynamic input shapes.
+            update_output_names (list[str]): List of output names to use in the trt engines.
+            enable_refit (bool): Enables the engine to be refitted with new weights after it is built.
+            enable_all_tactics (bool): Enables TRT to leverage all tactics or not.
+            timing_cache (str): A path or file-like object from which to load a tactic timing cache.
+            native_instancenorm (bool): support of instancenorm plugin.
+            builder_optimization_level (int): The builder optimization level.
+            precision_constraints (str):  If set to “obey”, require that layers execute in specified precisions. If set to “prefer”, prefer that layers execute in specified precisions but allow TRT to fall back to other precisions if no implementation exists for the requested precision. Otherwise, precision constraints are ignored.
+            verbose (bool): Weather to support verbose output
+
+        Returns:
+            dict[str, Any]: A dictionary representing the input profile configuration.
+        """
         print(f"Building TensorRT engine for {onnx_path}: {engine_path}")
 
         # Base command

--- a/src/flux/trt/trt_config/clip_trt_config.py
+++ b/src/flux/trt/trt_config/clip_trt_config.py
@@ -1,0 +1,69 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from flux.modules.conditioner import HFEmbedder
+from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config
+
+
+@register_config(model_name="clip", tf32=True, bf16=True, fp8=False, fp4=False)
+@register_config(model_name="clip", tf32=True, bf16=False, fp8=True, fp4=False)
+@register_config(model_name="clip", tf32=True, bf16=False, fp8=False, fp4=True)
+@dataclass
+class ClipConfig(TRTBaseConfig):
+    text_maxlen: int | None = None
+    hidden_size: int | None = None
+    model_name: str = "clip"
+    trt_tf32: bool = True
+    trt_bf16: bool = True
+    trt_fp8: bool = False
+    trt_fp4: bool = False
+    trt_build_strongly_typed: bool = False
+
+    @classmethod
+    def from_model(
+        cls,
+        model: HFEmbedder,
+        **kwargs,
+    ):
+        return cls(
+            text_maxlen=model.max_length,
+            hidden_size=model.hf_module.config.hidden_size,
+            **kwargs,
+        )
+
+    def check_dims(self, batch_size: int) -> None:
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+
+    def get_input_profile(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        min_batch = batch_size if static_batch else self.min_batch
+        max_batch = batch_size if static_batch else self.max_batch
+
+        self.check_dims(batch_size)
+        return {
+            "input_ids": [
+                (min_batch, self.text_maxlen),
+                (batch_size, self.text_maxlen),
+                (max_batch, self.text_maxlen),
+            ]
+        }

--- a/src/flux/trt/trt_config/t5_trt_config.py
+++ b/src/flux/trt/trt_config/t5_trt_config.py
@@ -1,0 +1,73 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from flux.modules.conditioner import HFEmbedder
+from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config
+
+
+@dataclass
+class T5BaseConfig(TRTBaseConfig):
+    text_maxlen: int | None = None
+    hidden_size: int | None = None
+
+    @classmethod
+    def from_model(
+        cls,
+        model: HFEmbedder,
+        **kwargs,
+    ):
+        return cls(
+            text_maxlen=model.max_length,
+            hidden_size=model.hf_module.config.hidden_size,
+            **kwargs,
+        )
+
+    def check_dims(self, batch_size: int) -> None:
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+
+    def get_input_profile(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        min_batch = batch_size if static_batch else self.min_batch
+        max_batch = batch_size if static_batch else self.max_batch
+
+        self.check_dims(batch_size)
+        return {
+            "input_ids": [
+                (min_batch, self.text_maxlen),
+                (batch_size, self.text_maxlen),
+                (max_batch, self.text_maxlen),
+            ]
+        }
+
+
+@register_config(model_name="t5", tf32=True, bf16=True, fp8=False, fp4=False)
+@register_config(model_name="t5", tf32=True, bf16=False, fp8=True, fp4=False)
+@register_config(model_name="t5", tf32=True, bf16=False, fp8=False, fp4=True)
+@dataclass
+class T5Config(T5BaseConfig):
+    model_name: str = "t5"
+    trt_tf32: bool = True
+    trt_bf16: bool = False
+    trt_fp8: bool = False
+    trt_fp4: bool = False
+    trt_build_strongly_typed: bool = True

--- a/src/flux/trt/trt_config/transformer_trt_config.py
+++ b/src/flux/trt/trt_config/transformer_trt_config.py
@@ -1,0 +1,189 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from dataclasses import dataclass, field
+from math import ceil
+
+from tensorrt import __version__ as trt_version
+from flux.model import Flux
+from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config
+
+
+@register_config(model_name="transformer", tf32=True, bf16=True, fp8=False, fp4=False)
+@register_config(model_name="transformer", tf32=True, bf16=False, fp8=True, fp4=False)
+@register_config(model_name="transformer", tf32=True, bf16=False, fp8=False, fp4=True)
+@dataclass
+class TransformerConfig(TRTBaseConfig):
+    guidance_embed: int | None = None
+    vec_in_dim: int | None = None
+    context_in_dim: int | None = None
+    in_channels: int | None = None
+    out_channels: int | None = None
+
+    compression_factor: int = 8
+    text_maxlen: int = 512
+    min_image_shape: int = 768
+    max_image_shape: int = 1344
+    min_latent_shape: int = field(init=False)
+    max_latent_shape: int = field(init=False)
+
+    model_name: str = "transformer"
+    trt_tf32: bool = True
+    trt_bf16: bool = False
+    trt_fp8: bool = False
+    trt_fp4: bool = False
+    trt_build_strongly_typed: bool = True
+
+    @classmethod
+    def from_model(
+        cls,
+        model: Flux,
+        **kwargs,
+    ):
+        return cls(
+            guidance_embed=model.params.guidance_embed,
+            vec_in_dim=model.params.vec_in_dim,
+            context_in_dim=model.params.context_in_dim,
+            in_channels=model.params.in_channels,
+            out_channels=model.out_channels,
+            **kwargs,
+        )
+
+    def _get_onnx_path(self) -> str:
+        # override base implementation to support transformer precision
+        return os.path.join(
+            self.onnx_dir,
+            self.model_name + ".opt",
+            self.precision,
+            "model.onnx",
+        )
+
+    def _get_engine_path(self) -> str:
+        # override base implementation to support transformer precision
+        return os.path.join(
+            self.engine_dir,
+            f"{self.model_name}_{self.precision}.trt{trt_version}.plan",
+        )
+
+    def _get_latent_dim(self, image_dim: int) -> int:
+        return 2 * ceil(image_dim / (2 * self.compression_factor))
+
+    def __post_init__(self):
+        self.min_latent_shape = self._get_latent_dim(self.min_image_shape)
+        self.max_latent_shape = self._get_latent_dim(self.max_image_shape)
+        super().__post_init__()
+
+    def get_minmax_dims(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        min_batch = batch_size if static_batch else self.min_batch
+        max_batch = batch_size if static_batch else self.max_batch
+
+        latent_height = self._get_latent_dim(image_height)
+        latent_width = self._get_latent_dim(image_width)
+        min_latent_height = latent_height if static_shape else self.min_latent_shape
+        max_latent_height = latent_height if static_shape else self.max_latent_shape
+        min_latent_width = latent_width if static_shape else self.min_latent_shape
+        max_latent_width = latent_width if static_shape else self.max_latent_shape
+
+        return (
+            min_batch,
+            max_batch,
+            min_latent_height,
+            max_latent_height,
+            min_latent_width,
+            max_latent_width,
+        )
+
+    def check_dims(self, batch_size: int, image_height: int, image_width: int) -> tuple[int, int]:
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+        assert image_height % self.compression_factor == 0 or image_width % self.compression_factor == 0
+
+        latent_height = self._get_latent_dim(image_height)
+        latent_width = self._get_latent_dim(image_width)
+
+        assert latent_height >= self.min_latent_shape and latent_height <= self.max_latent_shape
+        assert latent_width >= self.min_latent_shape and latent_width <= self.max_latent_shape
+        return (latent_height, latent_width)
+
+    def get_input_profile(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ) -> dict[str, list[tuple]]:
+        latent_height, latent_width = self.check_dims(
+            batch_size=batch_size,
+            image_height=image_height,
+            image_width=image_width,
+        )
+
+        (
+            min_batch,
+            max_batch,
+            min_latent_height,
+            max_latent_height,
+            min_latent_width,
+            max_latent_width,
+        ) = self.get_minmax_dims(
+            batch_size=batch_size,
+            image_height=image_height,
+            image_width=image_width,
+            static_batch=static_batch,
+            static_shape=static_shape,
+        )
+
+        input_profile = {
+            "hidden_states": [
+                (min_batch, (min_latent_height // 2) * (min_latent_width // 2), self.in_channels),
+                (batch_size, (latent_height // 2) * (latent_width // 2), self.in_channels),
+                (max_batch, (max_latent_height // 2) * (max_latent_width // 2), self.in_channels),
+            ],
+            "encoder_hidden_states": [
+                (min_batch, self.text_maxlen, self.context_in_dim),
+                (batch_size, self.text_maxlen, self.context_in_dim),
+                (max_batch, self.text_maxlen, self.context_in_dim),
+            ],
+            "pooled_projections": [
+                (min_batch, self.vec_in_dim),
+                (batch_size, self.vec_in_dim),
+                (max_batch, self.vec_in_dim),
+            ],
+            "img_ids": [
+                ((min_latent_height // 2) * (min_latent_width // 2), 3),
+                ((latent_height // 2) * (latent_width // 2), 3),
+                ((max_latent_height // 2) * (max_latent_width // 2), 3),
+            ],
+            "txt_ids": [
+                (self.text_maxlen, 3),
+                (self.text_maxlen, 3),
+                (self.text_maxlen, 3),
+            ],
+            "timestep": [(min_batch,), (batch_size,), (max_batch,)],
+        }
+
+        if self.guidance_embed:
+            input_profile["guidance"] = [(min_batch,), (batch_size,), (max_batch,)]
+
+        return input_profile

--- a/src/flux/trt/trt_config/transformer_trt_config.py
+++ b/src/flux/trt/trt_config/transformer_trt_config.py
@@ -28,7 +28,7 @@ from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config
 @register_config(model_name="transformer", tf32=True, bf16=False, fp8=False, fp4=True)
 @dataclass
 class TransformerConfig(TRTBaseConfig):
-    guidance_embed: int | None = None
+    guidance_embed: bool | None = None
     vec_in_dim: int | None = None
     context_in_dim: int | None = None
     in_channels: int | None = None

--- a/src/flux/trt/trt_config/vae_trt_config.py
+++ b/src/flux/trt/trt_config/vae_trt_config.py
@@ -19,7 +19,7 @@ from math import ceil
 from flux.modules.autoencoder import Decoder, Encoder
 from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config
 
-
+@dataclass
 class VAEBaseConfig(TRTBaseConfig):
     z_channels: int | None = None
     scale_factor: float | None = None

--- a/src/flux/trt/trt_config/vae_trt_config.py
+++ b/src/flux/trt/trt_config/vae_trt_config.py
@@ -1,0 +1,247 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 1993-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass, field
+from math import ceil
+
+from flux.modules.autoencoder import Decoder, Encoder
+from flux.trt.trt_config.base_trt_config import TRTBaseConfig, register_config
+
+
+class VAEBaseConfig(TRTBaseConfig):
+    z_channels: int | None = None
+    scale_factor: float | None = None
+    shift_factor: float | None = None
+
+    compression_factor: int = 8
+    min_image_shape: int = 768
+    max_image_shape: int = 1344
+    min_latent_shape: int = field(init=False)
+    max_latent_shape: int = field(init=False)
+
+    @classmethod
+    def from_model(
+        cls,
+        model: Encoder | Decoder,
+        **kwargs,
+    ):
+        return cls(
+            z_channels=model.params.z_channels,
+            scale_factor=model.params.scale_factor,
+            shift_factor=model.params.shift_factor,
+            **kwargs,
+        )
+
+    def _get_latent_dim(self, image_dim: int) -> int:
+        return 2 * ceil(image_dim / (2 * self.compression_factor))
+
+    def _get_img_dim(self, latent_dim: int) -> int:
+        return latent_dim * self.compression_factor
+
+    def __post_init__(self):
+        self.min_latent_shape = self._get_latent_dim(self.min_image_shape)
+        self.max_latent_shape = self._get_latent_dim(self.max_image_shape)
+        super().__post_init__()
+
+
+@register_config(model_name="vae", tf32=True, bf16=True, fp8=False, fp4=False)
+@register_config(model_name="vae", tf32=True, bf16=False, fp8=True, fp4=False)
+@register_config(model_name="vae", tf32=True, bf16=False, fp8=False, fp4=True)
+@dataclass
+class VAEDecoderConfig(VAEBaseConfig):
+    model_name: str = "vae"
+    trt_tf32: bool = True
+    trt_bf16: bool = True
+    trt_fp8: bool = False
+    trt_fp4: bool = False
+    trt_build_strongly_typed: bool = False
+
+    def check_dims(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+    ) -> tuple[int, int]:
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+        assert image_height % self.compression_factor == 0 or image_width % self.compression_factor == 0
+
+        latent_height = self._get_latent_dim(image_height)
+        latent_width = self._get_latent_dim(image_width)
+
+        assert latent_height >= self.min_latent_shape and latent_height <= self.max_latent_shape
+        assert latent_width >= self.min_latent_shape and latent_width <= self.max_latent_shape
+        return (latent_height, latent_width)
+
+    def get_minmax_dims(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        min_batch = batch_size if static_batch else self.min_batch
+        max_batch = batch_size if static_batch else self.max_batch
+
+        latent_height = self._get_latent_dim(image_height)
+        latent_width = self._get_latent_dim(image_width)
+
+        min_latent_height = latent_height if static_shape else self.min_latent_shape
+        max_latent_height = latent_height if static_shape else self.max_latent_shape
+        min_latent_width = latent_width if static_shape else self.min_latent_shape
+        max_latent_width = latent_width if static_shape else self.max_latent_shape
+
+        return (
+            min_batch,
+            max_batch,
+            min_latent_height,
+            max_latent_height,
+            min_latent_width,
+            max_latent_width,
+        )
+
+    def get_input_profile(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        latent_height, latent_width = self.check_dims(
+            batch_size=batch_size,
+            image_height=image_height,
+            image_width=image_width,
+        )
+
+        (
+            min_batch,
+            max_batch,
+            min_latent_height,
+            max_latent_height,
+            min_latent_width,
+            max_latent_width,
+        ) = self.get_minmax_dims(
+            batch_size=batch_size,
+            image_height=image_height,
+            image_width=image_width,
+            static_batch=static_batch,
+            static_shape=static_shape,
+        )
+
+        return {
+            "latent": [
+                (min_batch, self.z_channels, min_latent_height, min_latent_width),
+                (batch_size, self.z_channels, latent_height, latent_width),
+                (max_batch, self.z_channels, max_latent_height, max_latent_width),
+            ]
+        }
+
+@register_config(model_name="vae_encoder", tf32=True, bf16=True, fp8=False, fp4=False)
+@register_config(model_name="vae_encoder", tf32=True, bf16=False, fp8=True, fp4=False)
+@register_config(model_name="vae_encoder", tf32=True, bf16=False, fp8=False, fp4=True)
+@dataclass
+class VAEEncoderConfig(VAEBaseConfig):
+    model_name: str = "vae_encoder"
+    trt_tf32: bool = True
+    trt_bf16: bool = True
+    trt_fp8: bool = False
+    trt_fp4: bool = False
+    trt_build_strongly_typed: bool = False
+
+    def __post_init__(self):
+        self.min_latent_shape = self._get_latent_dim(self.min_image_shape)
+        self.max_latent_shape = self._get_latent_dim(self.max_image_shape)
+        super().__post_init__()
+
+    def check_dims(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+    ) -> tuple[int, int]:
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+        assert batch_size >= self.min_batch and batch_size <= self.max_batch
+        assert image_height % self.compression_factor == 0 or image_width % self.compression_factor == 0
+
+        latent_height = self._get_latent_dim(image_height)
+        latent_width = self._get_latent_dim(image_width)
+
+        assert latent_height >= self.min_latent_shape and latent_height <= self.max_latent_shape
+        assert latent_width >= self.min_latent_shape and latent_width <= self.max_latent_shape
+        return (latent_height, latent_width)
+
+    def get_minmax_dims(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        min_batch = batch_size if static_batch else self.min_batch
+        max_batch = batch_size if static_batch else self.max_batch
+
+        min_image_height = image_height if static_shape else self.min_image_shape
+        max_image_height = image_height if static_shape else self.max_image_shape
+        min_image_width = image_width if static_shape else self.min_image_shape
+        max_image_width = image_width if static_shape else self.max_image_shape
+
+        return (
+            min_batch,
+            max_batch,
+            min_image_height,
+            max_image_height,
+            min_image_width,
+            max_image_width,
+        )
+
+    def get_input_profile(
+        self,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
+        static_batch: bool,
+        static_shape: bool,
+    ):
+        self.check_dims(
+            batch_size=batch_size,
+            image_height=image_height,
+            image_width=image_width,
+        )
+
+        (
+            min_batch,
+            max_batch,
+            min_image_height,
+            max_image_height,
+            min_image_width,
+            max_image_width,
+        ) = self.get_minmax_dims(
+            batch_size=batch_size,
+            image_height=image_height,
+            image_width=image_width,
+            static_batch=static_batch,
+            static_shape=static_shape,
+        )
+
+        return {
+            "images": [
+                (min_batch, 3, min_image_height, min_image_width),
+                (batch_size, 3, image_height, image_width),
+                (max_batch, 3, max_image_height, max_image_width),
+            ],
+        }


### PR DESCRIPTION
This PR is in charge of adding a trt-config class.
This class is responsible to build the trt engine given an onnx path and various trt-flags.

As the same model might need different trt-configurations depending on which precision is used, a [registry](https://github.com/andompesta/flux/pull/9/files#diff-85690c5e7fc4a750e1af6114cf558c7156c1a04316fc310ea21eea04dce41922R27) is used to collect all the model configuration.
Based on the provided `key` the [get_config](https://github.com/andompesta/flux/pull/9/files#diff-85690c5e7fc4a750e1af6114cf558c7156c1a04316fc310ea21eea04dce41922R232) method will return the appropriate model configuration to use. 


Each configuration is a dataclass containing:
-  the needed trt flags
- a `from_model` factory method to feed all needed parameters to the config class
- an `get_input_profile` method that return the max and mix input supported by the build engine

Engine classes are changed to:
- use trt-config class instead of mixin classes 