### PR TITLE
Trt refactor trt manager

### DIFF
--- a/src/flux/trt/trt_manager.py
+++ b/src/flux/trt/trt_manager.py
@@ -53,7 +53,6 @@ class TRTManager:
 
     def __init__(
         self,
-        device: str | torch.device,
         max_batch=2,
         tf32=True,
         bf16=False,
@@ -62,7 +61,6 @@ class TRTManager:
         verbose=False,
     ):
         assert bf16 + fp8 + fp4 == 1, "only one model type can be active"
-        self.device = device
         self.max_batch = max_batch
         self.tf32 = tf32
         self.bf16 = bf16

--- a/src/flux/trt/trt_manager.py
+++ b/src/flux/trt/trt_manager.py
@@ -131,9 +131,9 @@ class TRTManager:
     @staticmethod
     def _build_engine(
         trt_config: TRTBaseConfig,
-        opt_batch_size: int,
-        opt_image_height: int,
-        opt_image_width: int,
+        batch_size: int,
+        image_height: int,
+        image_width: int,
     ):
         already_build = os.path.exists(trt_config.engine_path)
         if already_build:
@@ -148,9 +148,9 @@ class TRTManager:
             fp8=trt_config.trt_fp8,
             fp4=trt_config.trt_fp4,
             input_profile=trt_config.get_input_profile(
-                batch_size=opt_batch_size,
-                image_height=opt_image_height,
-                image_width=opt_image_width,
+                batch_size=batch_size,
+                image_height=image_height,
+                image_width=image_width,
                 static_batch=trt_config.trt_static_batch,
                 static_shape=trt_config.trt_static_shape,
             ),
@@ -170,9 +170,9 @@ class TRTManager:
         models: dict[str, torch.nn.Module],
         engine_dir: str,
         onnx_dir: str,
-        opt_image_height: int,
-        opt_image_width: int,
-        opt_batch_size=1,
+        trt_image_height: int,
+        trt_image_width: int,
+        trt_batch_size=1,
         trt_static_batch=True,
         trt_static_shape=True,
         trt_enable_all_tactics=False,
@@ -203,9 +203,9 @@ class TRTManager:
         for model_name, trt_config in trt_configs.items():
             self._build_engine(
                 trt_config=trt_config,
-                opt_batch_size=opt_batch_size,
-                opt_image_height=opt_image_height,
-                opt_image_width=opt_image_width,
+                batch_size=trt_batch_size,
+                image_height=trt_image_height,
+                image_width=trt_image_width,
             )
 
         gc.collect()

--- a/src/flux/trt/trt_manager.py
+++ b/src/flux/trt/trt_manager.py
@@ -17,7 +17,6 @@ import gc
 import os
 import sys
 import warnings
-from typing import Any, Union
 
 import tensorrt as trt
 import torch
@@ -26,28 +25,24 @@ from cuda import cudart
 from flux.trt.engine import (
     BaseEngine,
     CLIPEngine,
+    Engine,
     T5Engine,
     TransformerEngine,
     VAEDecoder,
     VAEEncoder,
     VAEEngine,
 )
-from flux.trt.exporter import (
-    BaseExporter,
-    CLIPExporter,
-    T5Exporter,
-    TransformerExporter,
-    VAEDecoderExporter,
-    VAEEncoderExporter,
+from flux.trt.trt_config import (
+    TRTBaseConfig,
+    get_config,
 )
-from flux.trt.mixin import BaseMixin
 
 TRT_LOGGER = trt.Logger()
 
 
 class TRTManager:
     @property
-    def model_to_engine_class(self) -> dict[str, type[Union[BaseMixin, BaseEngine]]]:
+    def model_to_engine_class(self) -> dict[str, type[Engine]]:
         return {
             "clip": CLIPEngine,
             "transformer": TransformerEngine,
@@ -56,35 +51,23 @@ class TRTManager:
             "vae_encoder": VAEEncoder,
         }
 
-    @property
-    def model_to_exporter_dict(self) -> dict[str, type[Union[BaseMixin, BaseExporter]]]:
-        return {
-            "clip": CLIPExporter,
-            "transformer": TransformerExporter,
-            "t5": T5Exporter,
-            "vae": VAEDecoderExporter,
-            "vae_encoder": VAEEncoderExporter,
-        }
-
     def __init__(
         self,
         device: str | torch.device,
-        max_batch=1,
-        fp16=False,
-        bf16=False,
+        max_batch=2,
         tf32=True,
-        static_batch=True,
-        static_shape=True,
-        verbose=True,
-        **kwargs,
+        bf16=False,
+        fp8=False,
+        fp4=False,
+        verbose=False,
     ):
+        assert bf16 + fp8 + fp4 == 1, "only one model type can be active"
         self.device = device
         self.max_batch = max_batch
-        self.fp16 = fp16
-        self.bf16 = bf16
         self.tf32 = tf32
-        self.static_batch = static_batch
-        self.static_shape = static_shape
+        self.bf16 = bf16
+        self.fp8 = fp8
+        self.fp4 = fp4
         self.verbose = verbose
         self.runtime: trt.Runtime = None
 
@@ -97,225 +80,85 @@ class TRTManager:
             print(f"[I] Create directory: {directory} if not existing")
             os.makedirs(directory, exist_ok=True)
 
-    @staticmethod
-    def _get_onnx_path(
-        model_name: str,
-        onnx_dir: str,
-        opt: bool = True,
-        suffix: str = "",
-        transformer_precision: str = "bf16",
-    ) -> str:
-        onnx_model_dir = os.path.join(
-            onnx_dir,
-            model_name + suffix + (".opt" if opt else ""),
-        )
-        if model_name == "transformer":
-            onnx_model_dir = os.path.join(onnx_model_dir, transformer_precision)
-        os.makedirs(onnx_model_dir, exist_ok=True)
-        return os.path.join(onnx_model_dir, "model.onnx")
-
-    @staticmethod
-    def _get_engine_path(
-        model_name: str,
-        engine_dir: str,
-        suffix: str = "",
-        transformer_precision: str = "bf16",
-    ) -> str:
-        return os.path.join(
-            engine_dir,
-            model_name
-            + suffix
-            + (f"_{transformer_precision}" if model_name == "transformer" else "")
-            + ".trt"
-            + trt.__version__
-            + ".plan",
-        )
-
-    @staticmethod
-    def _get_weights_map_path(
-        model_name: str,
-        onnx_dir: str,
-    ) -> str:
-        onnx_model_dir = os.path.join(onnx_dir, model_name + ".opt")
-        os.makedirs(onnx_model_dir, exist_ok=True)
-        return os.path.join(onnx_model_dir, "weights_map.json")
-
-    @staticmethod
-    def _get_refit_nodes_path(
-        model_name: str,
-        onnx_dir: str,
-        suffix: str = "",
-    ) -> str:
-        onnx_model_dir = os.path.join(onnx_dir, model_name + ".opt")
-        os.makedirs(onnx_model_dir, exist_ok=True)
-        return os.path.join(onnx_model_dir, "refit" + suffix + ".json")
-
-    @staticmethod
-    def _prepare_model_configs(
-        models: dict[str, torch.nn.Module],
-        engine_dir: str,
-        onnx_dir: str,
-        transformer_precision: str,
-    ) -> dict[str, dict[str, Any]]:
-        model_names = models.keys()
-        configs = {}
-        for model_name in model_names:
-            config: dict[str, Any] = {}
-            config["model_suffix"] = ""
-
-            config["onnx_path"] = TRTManager._get_onnx_path(
-                model_name=model_name,
-                onnx_dir=onnx_dir,
-                opt=False,
-                suffix=config["model_suffix"],
-                transformer_precision=transformer_precision,
-            )
-            config["onnx_opt_path"] = TRTManager._get_onnx_path(
-                model_name=model_name,
-                onnx_dir=onnx_dir,
-                suffix=config["model_suffix"],
-                transformer_precision=transformer_precision,
-            )
-            config["engine_path"] = TRTManager._get_engine_path(
-                model_name=model_name,
-                engine_dir=engine_dir,
-                suffix=config["model_suffix"],
-                transformer_precision=transformer_precision,
-            )
-
-            configs[model_name] = config
-
-        return configs
-
-    def _get_exporters(
+    def _get_trt_configs(
         self,
         models: dict[str, torch.nn.Module],
-    ) -> dict[str, Union[BaseMixin, BaseExporter]]:
-        exporters = {}
+        engine_dir: str,
+        onnx_dir: str,
+        trt_static_batch: bool,
+        trt_static_shape: bool,
+        trt_enable_all_tactics: bool,
+        trt_timing_cache: str | None,
+        trt_native_instancenorm: bool,
+        trt_builder_optimization_level: int,
+        trt_precision_constraints: str,
+    ) -> dict[str, TRTBaseConfig]:
+        trt_configs = {}
         for model_name, model in models.items():
-            exporter_class = self.model_to_exporter_dict[model_name]
+            config_cls = get_config(
+                model_name=model_name,
+                tf32=self.tf32,
+                bf16=self.bf16,
+                fp8=self.fp8,
+                fp4=self.fp4,
+            )
 
-            if model_name == "t5":
-                # traced in tf32 for numerical stability when on fp16
-                exporter = exporter_class(
-                    model=model,
-                    fp16=False,
-                    bf16=self.bf16,
-                    tf32=self.tf32,
-                    max_batch=self.max_batch,
-                    verbose=self.verbose,
-                )
-                exporters[model_name] = exporter
+            trt_config = config_cls.from_model(
+                model=model,
+                max_batch=self.max_batch,
+                onnx_dir=onnx_dir,
+                engine_dir=engine_dir,
+                trt_verbose=self.verbose,
+                precision="fp4" if self.fp4 else "fp8" if self.fp8 else "bf16",
+                trt_static_batch=trt_static_batch,
+                trt_static_shape=trt_static_shape,
+                trt_enable_all_tactics=trt_enable_all_tactics,
+                trt_timing_cache=trt_timing_cache,
+                trt_native_instancenorm=trt_native_instancenorm,
+                trt_builder_optimization_level=trt_builder_optimization_level,
+                trt_precision_constraints=trt_precision_constraints,
+            )
 
-            elif model_name.startswith("vae"):
-                # Accuracy issues with FP16 and BF16
-                # fallback to FP32
-                exporter = exporter_class(
-                    model=model,
-                    fp16=False,
-                    bf16=False,
-                    tf32=self.tf32,
-                    max_batch=self.max_batch,
-                    verbose=self.verbose,
-                )
-                exporters[model_name] = exporter
+            trt_configs[model_name] = trt_config
 
-            else:
-                onnx_exporter = exporter_class(
-                    model=model,
-                    fp16=self.fp16,
-                    bf16=self.bf16,
-                    tf32=self.tf32,
-                    max_batch=self.max_batch,
-                    verbose=self.verbose,
-                )
-                exporters[model_name] = onnx_exporter
-
-        if "transformer" in exporters and "t5" in exporters:
-            exporters["transformer"].text_maxlen = exporters["t5"].text_maxlen
+        if "transformer" in trt_configs and "t5" in trt_configs:
+            trt_configs["transformer"].text_maxlen = trt_configs["t5"].text_maxlen
         else:
             warnings.warn("`text_maxlen` attribute of flux-trasformer is not update. Default value is used.")
 
-        return exporters
-
-    def _export_onnx(
-        self,
-        model_exporter: Union[BaseMixin, BaseExporter],
-        model_config: dict[str, Any],
-        opt_image_height: int,
-        opt_image_width: int,
-        onnx_opset: int,
-    ):
-        do_export_onnx = not os.path.exists(model_config["engine_path"]) and not os.path.exists(
-            model_config["onnx_opt_path"]
-        )
-
-        model_exporter.model = model_exporter.model.to(self.device)
-
-        if do_export_onnx:
-            model_exporter.export_onnx(
-                onnx_path=model_config["onnx_path"],
-                onnx_opt_path=model_config["onnx_opt_path"],
-                onnx_opset=onnx_opset,
-                opt_image_height=opt_image_height,
-                opt_image_width=opt_image_width,
-            )
-
-        model_exporter.model = model_exporter.model.to("cpu")
-        gc.collect()
-        torch.cuda.empty_cache()
+        return trt_configs
 
     @staticmethod
     def _build_engine(
-        model_exporter: BaseExporter,
-        model_config: dict[str, Any],
+        trt_config: TRTBaseConfig,
         opt_batch_size: int,
         opt_image_height: int,
         opt_image_width: int,
-        static_batch: bool,
-        static_shape: bool,
-        optimization_level: int,
-        enable_all_tactics: bool,
-        timing_cache,
-        verbose: bool,
     ):
-        already_build = os.path.exists(model_config["engine_path"])
+        already_build = os.path.exists(trt_config.engine_path)
         if already_build:
             return
 
-        update_output_names = (
-            model_exporter.get_output_names() + model_exporter.extra_output_names
-            if model_exporter.extra_output_names
-            else None
-        )
-        fp16amp = False if getattr(model_exporter, "build_strongly_typed", False) else model_exporter.fp16
-        tf32amp = model_exporter.tf32
-        bf16amp = False if getattr(model_exporter, "build_strongly_typed", False) else model_exporter.bf16
-        strongly_typed = True if getattr(model_exporter, "build_strongly_typed", False) else False
-
-        extra_build_args = {
-            "verbose": verbose,
-            "builder_optimization_level": optimization_level,
-        }
-
-        model_exporter.build(
-            engine_path=model_config["engine_path"],
-            onnx_path=model_config["onnx_opt_path"],
-            strongly_typed=strongly_typed,
-            fp16=fp16amp,
-            tf32=tf32amp,
-            bf16=bf16amp,
-            input_profile=model_exporter.get_input_profile(
+        trt_config.build_trt_engine(
+            engine_path=trt_config.engine_path,
+            onnx_path=trt_config.onnx_path,
+            strongly_typed=trt_config.trt_build_strongly_typed,
+            tf32=trt_config.trt_tf32,
+            bf16=trt_config.trt_bf16,
+            fp8=trt_config.trt_fp8,
+            fp4=trt_config.trt_fp4,
+            input_profile=trt_config.get_input_profile(
                 batch_size=opt_batch_size,
                 image_height=opt_image_height,
                 image_width=opt_image_width,
-                static_batch=static_batch,
-                static_shape=static_shape,
+                static_batch=trt_config.trt_static_batch,
+                static_shape=trt_config.trt_static_shape,
             ),
-            enable_all_tactics=enable_all_tactics,
-            timing_cache=timing_cache,
-            update_output_names=update_output_names,
-            **extra_build_args,
+            enable_all_tactics=trt_config.trt_enable_all_tactics,
+            timing_cache=trt_config.trt_timing_cache,
+            update_output_names=trt_config.trt_update_output_names,
+            builder_optimization_level=trt_config.trt_builder_optimization_level,
+            verbose=trt_config.trt_verbose,
         )
 
         # Reclaim GPU memory from torch cache
@@ -329,65 +172,52 @@ class TRTManager:
         onnx_dir: str,
         opt_image_height: int,
         opt_image_width: int,
-        transformer_precision: str,
         opt_batch_size=1,
-        onnx_opset=19,
-        optimization_level=3,
-        enable_all_tactics=False,
-        timing_cache=None,
+        trt_static_batch=True,
+        trt_static_shape=True,
+        trt_enable_all_tactics=False,
+        trt_timing_cache: str | None = None,
+        trt_native_instancenorm=True,
+        trt_builder_optimization_level=3,
+        trt_precision_constraints="none",
     ) -> dict[str, BaseEngine]:
-        assert transformer_precision in ["bf16", "fp8", "fp4"], "Invalid transformer precision"
-
         self._create_directories(
             engine_dir=engine_dir,
             onnx_dir=onnx_dir,
         )
 
-        model_configs = self._prepare_model_configs(
-            models=models,
+        trt_configs = self._get_trt_configs(
+            models,
             engine_dir=engine_dir,
             onnx_dir=onnx_dir,
-            transformer_precision=transformer_precision,
+            trt_static_batch=trt_static_batch,
+            trt_static_shape=trt_static_shape,
+            trt_enable_all_tactics=trt_enable_all_tactics,
+            trt_timing_cache=trt_timing_cache,
+            trt_native_instancenorm=trt_native_instancenorm,
+            trt_builder_optimization_level=trt_builder_optimization_level,
+            trt_precision_constraints=trt_precision_constraints,
         )
 
-        exporters = self._get_exporters(models)
-
-        # Export models to ONNX
-        for model_name, model_exporter in exporters.items():
-            self._export_onnx(
-                model_exporter=model_exporter,
-                model_config=model_configs[model_name],
-                opt_image_height=opt_image_height,
-                opt_image_width=opt_image_width,
-                onnx_opset=onnx_opset,
-            )
-
         # Build TRT engines
-        for model_name, model_exporter in exporters.items():
-            model_config = model_configs[model_name]
+        for model_name, trt_config in trt_configs.items():
             self._build_engine(
-                model_exporter=model_exporter,
-                model_config=model_config,
+                trt_config=trt_config,
                 opt_batch_size=opt_batch_size,
                 opt_image_height=opt_image_height,
                 opt_image_width=opt_image_width,
-                static_batch=self.static_batch,
-                static_shape=self.static_shape,
-                optimization_level=optimization_level,
-                enable_all_tactics=enable_all_tactics,
-                timing_cache=timing_cache,
-                verbose=self.verbose,
             )
 
+        gc.collect()
+        torch.cuda.empty_cache()
+        self.init_runtime()
         # load TRT engines
         engines = {}
-        for model_name, model_exporter in exporters.items():
-            model_config = model_configs[model_name]
-
+        for model_name, trt_config in trt_configs.items():
             engine_class = self.model_to_engine_class[model_name]
             engine = engine_class(
-                engine_path=model_config["engine_path"],
-                **model_exporter.get_mixin_params(),
+                trt_config=trt_config,
+                stream=self.stream,
             )
             engines[model_name] = engine
 
@@ -396,6 +226,8 @@ class TRTManager:
                 decoder=engines.pop("vae"),
                 encoder=engines.pop("vae_encoder", None),
             )
+        gc.collect()
+        torch.cuda.empty_cache()
         return engines
 
     @staticmethod
@@ -410,6 +242,7 @@ class TRTManager:
         return max_device_memory
 
     def init_runtime(self):
+        print("[I] Init TRT runtime")
         self.runtime = trt.Runtime(TRT_LOGGER)
         enter_fn = type(self.runtime).__enter__
         enter_fn(self.runtime)
@@ -420,3 +253,4 @@ class TRTManager:
         exit_fn(self.runtime, *sys.exc_info())
         cudart.cudaStreamDestroy(self.stream)
         del self.stream
+        print("[I] Stop TRT runtime")

--- a/src/flux/trt/trt_manager.py
+++ b/src/flux/trt/trt_manager.py
@@ -72,11 +72,9 @@ class TRTManager:
         assert torch.cuda.is_available(), "No cuda device available"
 
     @staticmethod
-    def _create_directories(engine_dir: str, onnx_dir: str):
-        # Create directories if missing
-        for directory in [engine_dir, onnx_dir]:
-            print(f"[I] Create directory: {directory} if not existing")
-            os.makedirs(directory, exist_ok=True)
+    def _create_directories(engine_dir: str):
+        print(f"[I] Create directory: {engine_dir} if not existing")
+        os.makedirs(engine_dir, exist_ok=True)
 
     def _get_trt_configs(
         self,
@@ -179,10 +177,7 @@ class TRTManager:
         trt_builder_optimization_level=3,
         trt_precision_constraints="none",
     ) -> dict[str, BaseEngine]:
-        self._create_directories(
-            engine_dir=engine_dir,
-            onnx_dir=onnx_dir,
-        )
+        self._create_directories(engine_dir=engine_dir)
 
         trt_configs = self._get_trt_configs(
             models,


### PR DESCRIPTION
This PR implements the changes on trt-manager to use trt-config classes instead of  `exporters` and `mixin`.
1. for each porvided model a trt-config is provided by [_get_trt_configs](https://github.com/andompesta/flux/compare/trt-refactor-remove-mixin...andompesta:flux:trt-refactor-trt-manager?expand=1#diff-12d2d67aaca2433bfe3cd5b8c66b0da7a4060365466632d598b9aa494dfa8b8cR79) method.
2. for each trt-config a [trt-engine is build](https://github.com/andompesta/flux/compare/trt-refactor-remove-mixin...andompesta:flux:trt-refactor-trt-manager?expand=1#diff-12d2d67aaca2433bfe3cd5b8c66b0da7a4060365466632d598b9aa494dfa8b8cR128). trt-build is fully based on trt-config classes. There is no more exporter/model_config split
3. after trt-engines are build, a [trt-runtime is initialized](https://github.com/andompesta/flux/compare/trt-refactor-remove-mixin...andompesta:flux:trt-refactor-trt-manager?expand=1#diff-12d2d67aaca2433bfe3cd5b8c66b0da7a4060365466632d598b9aa494dfa8b8cR206)
4. finally engine classes are [instantiated](https://github.com/andompesta/flux/compare/trt-refactor-remove-mixin...andompesta:flux:trt-refactor-trt-manager?expand=1#diff-12d2d67aaca2433bfe3cd5b8c66b0da7a4060365466632d598b9aa494dfa8b8cR211) with a valid cuda-stream



this PR greatly simplify this class by reducing code lines by half
 