### PR TITLE
Trt refactor clis

### DIFF
--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -10,7 +10,12 @@ from fire import Fire
 from transformers import pipeline
 
 from flux.sampling import denoise, get_noise, get_schedule, prepare, unpack
-from flux.trt.trt_manager import TRTManager
+try:
+    from flux.trt.trt_manager import TRTManager
+    TRT_AVAIABLE = True
+except:  # noqa: E722
+    TRT_AVAIABLE = False
+
 from flux.util import configs, load_ae, load_clip, load_flow_model, load_t5, save_image
 
 NSFW_THRESHOLD = 0.85
@@ -110,8 +115,9 @@ def main(
     offload: bool = False,
     output_dir: str = "output",
     add_sampling_metadata: bool = True,
-    trt: bool = False,
-    trt_transformer_precision: str = "bf16",
+    trt_onnx_dir: str | None = None,
+    trt_engine_dir: str | None = None,
+    trt_precision: str = "bf16",
     **kwargs: dict | None,
 ):
     """
@@ -178,42 +184,42 @@ def main(
     model = load_flow_model(name, device="cpu" if offload else torch_device)
     ae = load_ae(name, device="cpu" if offload else torch_device)
 
-    if trt:
-        # offload to CPU to save memory
-        ae = ae.cpu()
-        model = model.cpu()
-        clip = clip.cpu()
-        t5 = t5.cpu()
+    if trt_onnx_dir is not None and trt_engine_dir is not None:
+        if not TRT_AVAIABLE:
+            raise ModuleNotFoundError(
+                "TRT dependencies are needed. Follow README instruction to setup the tensorrt environment."
+            )
 
-        torch.cuda.empty_cache()
+        if trt_precision == "bf16":
+            bf16, fp8, fp4 = True, False, False
+        elif trt_precision == "fp8":
+            bf16, fp8, fp4 = False, True, False
+        elif trt_precision == "fp4":
+            bf16, fp8, fp4 = False, False, True
+        else:
+            raise NotImplementedError(
+                f"precision {trt_precision} is not supported. Only `bf16`, `fp8` or `fp4` are valid values."
+            )
 
-        trt_ctx_manager = TRTManager(
-            bf16=True,
-            device=torch_device,
-            static_batch=kwargs.get("static_batch", True),
-            static_shape=kwargs.get("static_shape", True),
-        )
+        trt_ctx_manager = TRTManager(bf16=bf16, fp8=fp8, fp4=fp4)
+
         ae.decoder.params = ae.params
         engines = trt_ctx_manager.load_engines(
             models={
-                "clip": clip,
-                "transformer": model,
-                "t5": t5,
-                "vae": ae.decoder,
+                "clip": clip.cpu(),
+                "transformer": model.cpu(),
+                "t5": t5.cpu(),
+                "vae": ae.decoder.cpu(),
             },
-            engine_dir=os.environ.get("TRT_ENGINE_DIR", "./engines"),
-            onnx_dir=os.environ.get("ONNX_DIR", "./onnx"),
-            opt_image_height=height,
-            opt_image_width=width,
-            transformer_precision=trt_transformer_precision,
+            engine_dir=trt_engine_dir,
+            onnx_dir=trt_onnx_dir,
+            trt_image_height=height,
+            trt_image_width=width,
+            trt_batch_size=kwargs.get("trt_batch_size", 1),
+            trt_static_batch=kwargs.get("trt_static_batch", True),
+            trt_static_shape=kwargs.get("trt_static_shape", True),
         )
-
         torch.cuda.synchronize()
-
-        trt_ctx_manager.init_runtime()
-        # TODO: refactor. stream should be part of engine constructor maybe !!
-        for _, engine in engines.items():
-            engine.set_stream(stream=trt_ctx_manager.stream)
 
         if not offload:
             for _, engine in engines.items():
@@ -304,7 +310,7 @@ def main(
         else:
             opts = None
 
-    if trt:
+    if trt_onnx_dir is not None and trt_engine_dir is not None:
         trt_ctx_manager.stop_runtime()
 
 

--- a/src/flux/cli_control.py
+++ b/src/flux/cli_control.py
@@ -183,8 +183,6 @@ def main(
     trt_onnx_dir: str | None = None,
     trt_engine_dir: str | None = None,
     trt_precision: str = "bf16",
-    trt_static_batch: bool = True,
-    trt_static_shape: bool = True,
     **kwargs: dict | None,
 ):
     """
@@ -247,7 +245,7 @@ def main(
 
     # set lora scale
     if "lora" in name and lora_scale is not None:
-        assert not trt, "TRT does not support LORA yet"
+        assert not trt_onnx_dir and not trt_engine_dir, "TRT does not support LORA"
         for _, module in model.named_modules():
             if hasattr(module, "set_scale"):
                 module.set_scale(lora_scale)

--- a/src/flux/cli_control.py
+++ b/src/flux/cli_control.py
@@ -11,7 +11,10 @@ from transformers import pipeline
 
 from flux.modules.image_embedders import CannyImageEncoder, DepthImageEncoder
 from flux.sampling import denoise, get_noise, get_schedule, prepare_control, unpack
-from flux.trt.trt_manager import TRTManager
+try:
+    from flux.trt.trt_manager import TRTManager
+except:  # noqa: E722
+    print("trt engine not supported, install dependencies with `pip install -e \".[tensorrt]\" --extra-index-url https://pypi.nvidia.com`")
 from flux.util import configs, load_ae, load_clip, load_flow_model, load_t5, save_image
 
 
@@ -176,8 +179,11 @@ def main(
     add_sampling_metadata: bool = True,
     img_cond_path: str = "assets/robot.webp",
     lora_scale: float | None = 0.85,
-    trt: bool = False,
-    trt_transformer_precision: str = "bf16",
+    trt_onnx_dir: str | None = None,
+    trt_engine_dir: str | None = None,
+    trt_precision: str = "bf16",
+    trt_static_batch: bool = True,
+    trt_static_shape: bool = True,
     **kwargs: dict | None,
 ):
     """
@@ -252,12 +258,19 @@ def main(
     else:
         raise NotImplementedError()
 
-    if trt:
+    if trt_onnx_dir is not None and trt_engine_dir is not None:
+        if trt_precision == "bf16":
+            bf16, fp8, fp4 = True, False, False
+        elif trt_precision == "fp8":
+            bf16, fp8, fp4 = False, True, False
+        elif trt_precision == "fp4":
+            bf16, fp8, fp4 = False, False, True
+        else:
+            raise NotImplementedError(f"precision {trt_precision} is not supported. Only `bf16`, `fp8` or `fp4` are valid values")
         trt_ctx_manager = TRTManager(
-            bf16=True,
-            device=torch_device,
-            static_batch=kwargs.get("static_batch", True),
-            static_shape=kwargs.get("static_shape", True),
+            bf16=bf16,
+            fp8=fp8,
+            fp4=fp4,
         )
         ae.decoder.params = ae.params
         ae.encoder.params = ae.params
@@ -269,18 +282,15 @@ def main(
                 "vae": ae.decoder.cpu(),
                 "vae_encoder": ae.encoder.cpu(),
             },
-            engine_dir=os.environ.get("TRT_ENGINE_DIR", "./engines"),
-            onnx_dir=os.environ.get("ONNX_DIR", "./onnx"),
-            opt_image_height=height,
-            opt_image_width=width,
-            transformer_precision=trt_transformer_precision,
+            engine_dir=trt_engine_dir,
+            onnx_dir=trt_onnx_dir,
+            trt_image_height=height,
+            trt_image_width=width,
+            trt_batch_size=kwargs.get("trt_batch_size", 1),
+            trt_static_batch=kwargs.get("trt_static_batch", True),
+            trt_static_shape=kwargs.get("trt_static_shape", True),
         )
         torch.cuda.synchronize()
-
-        trt_ctx_manager.init_runtime()
-        # TODO: refactor. stream should be part of engine constructor maybe !!
-        for _, engine in engines.items():
-            engine.set_stream(stream=trt_ctx_manager.stream)
 
         if not offload:
             for _, engine in engines.items():
@@ -390,6 +400,8 @@ def main(
         else:
             opts = None
 
+    if trt_onnx_dir is not None and trt_engine_dir is not None:
+        trt_ctx_manager.stop_runtime()
 
 def app():
     Fire(main)

--- a/src/flux/cli_control.py
+++ b/src/flux/cli_control.py
@@ -260,7 +260,9 @@ def main(
     if trt_onnx_dir is not None and trt_engine_dir is not None:
 
         if not TRT_AVAIABLE:
-            raise ModuleNotFoundError("tensorrt dependencies are needed. Follow README instruction to setup the tensorrt environment.")
+            raise ModuleNotFoundError(
+                "TRT dependencies are needed. Follow README instruction to setup the tensorrt environment."
+            )
 
         if trt_precision == "bf16":
             bf16, fp8, fp4 = True, False, False
@@ -269,13 +271,12 @@ def main(
         elif trt_precision == "fp4":
             bf16, fp8, fp4 = False, False, True
         else:
-            raise NotImplementedError(f"precision {trt_precision} is not supported. Only `bf16`, `fp8` or `fp4` are valid values.")
+            raise NotImplementedError(
+                f"precision {trt_precision} is not supported. Only `bf16`, `fp8` or `fp4` are valid values."
+            )
 
-        trt_ctx_manager = TRTManager(
-            bf16=bf16,
-            fp8=fp8,
-            fp4=fp4,
-        )
+        trt_ctx_manager = TRTManager(bf16=bf16, fp8=fp8, fp4=fp4)
+
         ae.decoder.params = ae.params
         ae.encoder.params = ae.params
         engines = trt_ctx_manager.load_engines(

--- a/src/flux/cli_control.py
+++ b/src/flux/cli_control.py
@@ -13,8 +13,9 @@ from flux.modules.image_embedders import CannyImageEncoder, DepthImageEncoder
 from flux.sampling import denoise, get_noise, get_schedule, prepare_control, unpack
 try:
     from flux.trt.trt_manager import TRTManager
+    TRT_AVAIABLE = True
 except:  # noqa: E722
-    print("trt engine not supported, install dependencies with `pip install -e \".[tensorrt]\" --extra-index-url https://pypi.nvidia.com`")
+    TRT_AVAIABLE = False
 from flux.util import configs, load_ae, load_clip, load_flow_model, load_t5, save_image
 
 
@@ -259,6 +260,10 @@ def main(
         raise NotImplementedError()
 
     if trt_onnx_dir is not None and trt_engine_dir is not None:
+
+        if not TRT_AVAIABLE:
+            raise ModuleNotFoundError("tensorrt dependencies are needed. Follow README instruction to setup the tensorrt environment.")
+
         if trt_precision == "bf16":
             bf16, fp8, fp4 = True, False, False
         elif trt_precision == "fp8":
@@ -266,7 +271,8 @@ def main(
         elif trt_precision == "fp4":
             bf16, fp8, fp4 = False, False, True
         else:
-            raise NotImplementedError(f"precision {trt_precision} is not supported. Only `bf16`, `fp8` or `fp4` are valid values")
+            raise NotImplementedError(f"precision {trt_precision} is not supported. Only `bf16`, `fp8` or `fp4` are valid values.")
+
         trt_ctx_manager = TRTManager(
             bf16=bf16,
             fp8=fp8,


### PR DESCRIPTION
This PR change the CLI script to support the new TRT interface.
1. A `try ... except` approach is used to solve tensorrt import: people that do not install trt dependencies would experience an error otherwise.
2. Instead of using
```
trt: bool = False,
trt_transformer_precision: str = "bf16",
```
a different set of inputs are used:
- `trt_onnx_dir` is used to specify the folder containing onnx models
-  `trt_engine_dir` specify the location where trt engines will be loaded from or build
- `trt_precision` specify the precision of the pipeline. For now the supported precision are: bf16, fp8 and fp4
- `trt_batch_size` the batch size used to optimize the engine, by default 1
- `trt_static_batch` weather the engine is build with static batch size, by default yes
- `trt_static_shape` weather the engine is build to support static image shape, by default yes
All of these 3 args are needed to run trt engines. I found this approach to be easier rather than using a mix of input args and env-variables.

Note that:
- Based on the provided `trt_precision` a set of input values are generated for the [trt-manager class](https://github.com/andompesta/flux/compare/trt-refactor-remove-mixin...andompesta:flux:trt-refactor-clis?expand=1#diff-07cec30a86f0fa77b9f50dbc9889af78fe6365f6da30c7bc83e32cf753ec91efR193).
- if TRT is not available, but input arguments are provided: an [error](https://github.com/andompesta/flux/compare/trt-refactor-remove-mixin...andompesta:flux:trt-refactor-clis?expand=1#diff-07cec30a86f0fa77b9f50dbc9889af78fe6365f6da30c7bc83e32cf753ec91efR189) is raised
- all trt related input arguments start with `trt-` prefix